### PR TITLE
Fix repo link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cd pyhub
 
 Download the repo:
 ```
-git clone https://<username>@bitbucket.org/hues/pyhub.git
+git clone https://github.com/hues-platform/python-ehub.git
 ```
 
 Install the libraries needed for PyHub to run:


### PR DESCRIPTION
Was pointing to bitbucket, but now points to github since all the work
is there now.