### PR TITLE
Fix PyLP performance issue

### DIFF
--- a/pylp/expression.py
+++ b/pylp/expression.py
@@ -131,7 +131,11 @@ class Expression:
 
     @staticmethod
     def _handle_add(arguments: Iterable['Expression']):
-        return sum(arguments)
+        result = 0
+        for arg in arguments:
+            result += arg
+
+        return result
 
     @staticmethod
     def _handle_subtraction(arguments: List['Expression']):


### PR DESCRIPTION
The issue popped up while running the full 8760 problem.

The issue was due to PuLP copying a lot when nothing was needed to be
copied. By "unravelling" the `sum` call, the performance problem was
fixed.

cProfile was used to find the hotspot.